### PR TITLE
Fix skipped notes by handling multi-event USB MIDI packets

### DIFF
--- a/MidiMonger2/src/MidiControl.cpp
+++ b/MidiMonger2/src/MidiControl.cpp
@@ -210,7 +210,8 @@ void MidiControl::MidiEvent(const uint32_t data)
 
 					if (noteToAssign) {
 						for (uint8_t ch = 0; ch < 4; ++ch) {
-							uint8_t c = (ch + channelNotes[gate.channel].lastVoice) & 3;			// Round robin loop: start from next channel after the last one played
+							// gate.channel is 1‑based; channelNotes[] is 0‑based
+							uint8_t c = (ch + channelNotes[gate.channel - 1].lastVoice) & 3;			// Round robin loop: start from next channel after the last one played
 
 							if (cvOutputs[c].nextNote == 0 && cvOutputs[c].channel == gate.channel && cvOutputs[c].type == CvType::channelPitch) {
 								cvOutputs[c].nextNote = noteToAssign;
@@ -232,7 +233,8 @@ void MidiControl::MidiEvent(const uint32_t data)
 								cvOutputs[c].SendNote();
 								gateOutputs[c].output.SetHigh();
 							}
-							channelNotes[gate.channel].lastVoice = c + 1;			// Round robin loop: set up next start channel
+							// gate.channel is 1‑based; channelNotes[] is 0‑based
+							channelNotes[gate.channel - 1].lastVoice = c + 1;			// Round robin loop: set up next start channel
 						}
 						cvOutputs[c].nextNote = 0;
 					}

--- a/MidiMonger2/src/USBDevice/MidiHandler.cpp
+++ b/MidiMonger2/src/USBDevice/MidiHandler.cpp
@@ -14,9 +14,13 @@ void MidiHandler::DataIn()
 
 void MidiHandler::DataOut()
 {
-	// Handle incoming midi command here
-	if (outBuffCount == 4) {
-		midiControl.MidiEvent(*outBuff);
+	// Handle incoming MIDI commands here
+	if (outBuffCount >= 4 && outBuff[1] != 0xF0) {
+		// One or more standard USB‑MIDI event packets: process all 32‑bit words
+		const uint32_t eventCount = outBuffCount / 4;
+		for (uint32_t i = 0; i < eventCount; ++i) {
+			midiControl.MidiEvent(outBuff[i]);
+		}
 
 	} else if (outBuff[1] == 0xF0 && outBuffCount > 3) {		// Sysex - Doesn't do anything at present
 		// sysEx will be padded when supplied by usb - add only actual sysEx message bytes to array


### PR DESCRIPTION
I noticed MIDI Monger was skipping notes, this PR fixes that.

The main fix is in MidiHandler.cpp, if there are multiple MIDI commands in one packet, it will process all of those (Unless SysEx command)

The changes in MidiControl.cpp are just fixing some zero based indexing issues I noticed while digging around.